### PR TITLE
Fix fileName property via FrontMatter

### DIFF
--- a/src/find-file.ts
+++ b/src/find-file.ts
@@ -38,7 +38,7 @@ function getAttributes(files: PullsListFilesResponseItem[]): IFileProps[] {
       : {};
     return {
       filename: getFileName(
-        reqdAttributes["filename"],
+        reqdAttributes["fileName"],
         reqdAttributes["title"]
       ),
       attributes: reqdAttributes


### PR DESCRIPTION
Per Readme the front-matter attribute is `fileName` not `filename`.

found while trying to use the front matter parameter in https://github.com/staabm/staabm.github.io/pull/12 in which the action always used the kebab case title instead of the filename

caution: I was not able to verify this fix