### PR TITLE
Update GitHub Actions checkout to v4

### DIFF
--- a/.github/workflows/checkin.yml
+++ b/.github/workflows/checkin.yml
@@ -5,7 +5,7 @@ jobs:
   check_pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
       - name: "npm ci"
         run: npm ci

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     name: Generate OG Images
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Generate Image
         uses: ./ # Uses an action in the root directory
         env:


### PR DESCRIPTION
## Summary
- Updated actions/checkout from v1 to v4 in both workflow files
- v4 is the latest stable version with improved performance and security
- This addresses outdated action warnings in CI/CD pipeline

## Test plan
- [ ] GitHub Actions workflows should run successfully
- [ ] No deprecation warnings should appear in workflow logs

🤖 Generated with [opencode](https://opencode.ai)